### PR TITLE
add current date as a balance data-point

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -107,8 +107,8 @@ class AccountsController < IntranetController
     transactions = Transaction.transactions_with_totals(@account.transactions)
     transactions = transactions[0..(params[:limit].to_i - 1)] if params[:limit]
     balances = transactions.map { |t, b| [(t.date.to_time.to_i * 1000).to_s, b.to_s] }
-    balances =  [[(Date.today.to_time.to_i * 1000), balances.first.last]] + balances
-    render :json => balances
+    balances_with_today =  [[(Date.today.to_time.to_i * 1000).to_s, balances.first.last]] + balances
+    render :json => balances_with_today
   end
 
   def transactions

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -80,13 +80,13 @@ describe AccountsController do
       it "without a limit should return all them" do
         get :balances, :account_id => @account.id
         date = [Date.parse("2011-02-15"), Date.parse("2011-02-14"), Date.parse("2011-02-13")]
-        response.body.should == "[[\"#{date[0].to_time.to_i * 1000}\",\"0.0\"],[\"#{date[1].to_time.to_i * 1000}\",\"0.0\"],[\"#{date[2].to_time.to_i * 1000}\",\"100.0\"],[\"#{date[2].to_time.to_i * 1000}\",\"100.0\"]]"
+        response.body.should == "[[\"#{Date.today.to_time.to_i * 1000}\",\"0.0\"],[\"#{date[0].to_time.to_i * 1000}\",\"0.0\"],[\"#{date[1].to_time.to_i * 1000}\",\"0.0\"],[\"#{date[2].to_time.to_i * 1000}\",\"100.0\"]]"
       end
 
       it "with a limit should return a subset of balances" do
         get :balances, :limit => 2, :account_id => @account.id
         date = [Date.parse("2011-02-15"), Date.parse("2011-02-14"), Date.parse("2011-02-13")]
-        response.body.should == "[[\"#{date[0].to_time.to_i * 1000}\",\"0.0\"],[\"#{date[1].to_time.to_i * 1000}\",\"0.0\"],[\"#{date[1].to_time.to_i * 1000}\",\"0.0\"]]"
+        response.body.should == "[[\"#{Date.today.to_time.to_i * 1000}\",\"0.0\"],[\"#{date[0].to_time.to_i * 1000}\",\"0.0\"],[\"#{date[1].to_time.to_i * 1000}\",\"0.0\"]]"
       end
 
       it "should only allow the view of their own blances" do


### PR DESCRIPTION
this has bugged me for a while. 
I want to see when my account hasn't changed. To that end I want another data-point for the current day I'm on (even though it's not a transaction). This will help complete my picture of activity/ inactivity on my account. 

The line I added might not add the new entry to quite the right place in the array ( I note transactions_with_totals is doing some sorting and reversing D: ), so this def needs a smoke-test
